### PR TITLE
Add access to IRabbitMqReceiveEndpointConfigurator and update dependencies

### DIFF
--- a/src/MassTransit.RabbitMq.Extensions.Hosting/Configuration/MassTransitRabbitMqHostingBuilder.cs
+++ b/src/MassTransit.RabbitMq.Extensions.Hosting/Configuration/MassTransitRabbitMqHostingBuilder.cs
@@ -79,8 +79,12 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Configuration
         /// <typeparam name="TMessage">The type of the message.</typeparam>
         /// <param name="queueName">Name of the queue.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        public IMassTransitRabbitMqHostingBuilder Consume<TConsumer, TMessage>(string queueName, Action<IRetryConfigurator> retry = null)
+        public IMassTransitRabbitMqHostingBuilder Consume<TConsumer, TMessage>(
+            string queueName, 
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class
         {
@@ -98,6 +102,7 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Configuration
             }
 
             config.Types.Add(typeof(TConsumer));
+
             if (retry != null)
             {
                 if (config.RetryConfigurator != null)
@@ -106,6 +111,18 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Configuration
                 }
 
                 config.RetryConfigurator = retry;
+            }
+
+            if (receiveEndpointConfigurator != null)
+            {
+                if (config.ReceiveEndpointConfigurator != null)
+                {
+                    throw new ArgumentException(
+                        "Endpoint configurator already configured for queue: " + queueName, 
+                        nameof(receiveEndpointConfigurator));
+                }
+
+                config.ReceiveEndpointConfigurator = receiveEndpointConfigurator;
             }
 
             return this;

--- a/src/MassTransit.RabbitMq.Extensions.Hosting/Configuration/MassTransitRabbitMqHostingConfigurator.cs
+++ b/src/MassTransit.RabbitMq.Extensions.Hosting/Configuration/MassTransitRabbitMqHostingConfigurator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using GreenPipes;
-using GreenPipes.Configurators;
 using MassTransit.RabbitMq.Extensions.Hosting.Contracts;
 using MassTransit.RabbitMqTransport;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +41,8 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Configuration
             {
                 configure.ReceiveEndpoint(host, kvp.Key, c =>
                                                          {
+                                                             kvp.Value.ReceiveEndpointConfigurator?.Invoke(c);
+
                                                              if (kvp.Value.RetryConfigurator != null)
                                                              {
                                                                  c.UseRetry(kvp.Value.RetryConfigurator);

--- a/src/MassTransit.RabbitMq.Extensions.Hosting/Configuration/ReceiverConfiguration.cs
+++ b/src/MassTransit.RabbitMq.Extensions.Hosting/Configuration/ReceiverConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using GreenPipes.Configurators;
+using MassTransit.RabbitMqTransport;
 
 namespace MassTransit.RabbitMq.Extensions.Hosting.Configuration
 {
@@ -18,5 +19,10 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Configuration
         /// Gets or sets the retry configurator to apply on this configured receive endpoint.
         /// </summary>
         public Action<IRetryConfigurator> RetryConfigurator { get; set; }
+
+        /// <summary>
+        /// Gets or sets the bus configurator to apply on this configured receive endpoint.
+        /// </summary>
+        public Action<IRabbitMqReceiveEndpointConfigurator> ReceiveEndpointConfigurator { get; set; }
     }
 }

--- a/src/MassTransit.RabbitMq.Extensions.Hosting/Contracts/IMassTransitRabbitMqHostingBuilder.cs
+++ b/src/MassTransit.RabbitMq.Extensions.Hosting/Contracts/IMassTransitRabbitMqHostingBuilder.cs
@@ -30,8 +30,12 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Contracts
         /// <typeparam name="TMessage">The type of the message.</typeparam>
         /// <param name="queueName">Name of the queue.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        IMassTransitRabbitMqHostingBuilder Consume<TConsumer, TMessage>(string queueName, Action<IRetryConfigurator> retry = null)
+        IMassTransitRabbitMqHostingBuilder Consume<TConsumer, TMessage>(
+            string queueName, 
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class;
 

--- a/src/MassTransit.RabbitMq.Extensions.Hosting/Extensions/HostingBuilderExtensions.cs
+++ b/src/MassTransit.RabbitMq.Extensions.Hosting/Extensions/HostingBuilderExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Text.RegularExpressions;
 using GreenPipes.Configurators;
 using Humanizer;
 using MassTransit.RabbitMq.Extensions.Hosting.Contracts;
+using MassTransit.RabbitMqTransport;
 
 namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
 {
@@ -21,8 +21,9 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
         /// <param name="builder">The builder.</param>
         /// <param name="remoteApplicationName">Name of the remote application.</param>
         /// <returns></returns>
-        public static IMassTransitRabbitMqHostingBuilder WithFireAndForgetSendEndpointByConvention<TMessage>(this IMassTransitRabbitMqHostingBuilder builder,
-                                                                                                string remoteApplicationName)
+        public static IMassTransitRabbitMqHostingBuilder WithFireAndForgetSendEndpointByConvention<TMessage>(
+            this IMassTransitRabbitMqHostingBuilder builder,
+            string remoteApplicationName)
             => builder.WithFireAndForgetSendEndpoint<TMessage>(GetQueueName<TMessage>(remoteApplicationName));
 
         /// <summary>
@@ -32,12 +33,15 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
         /// <typeparam name="TMessage">The type of the message.</typeparam>
         /// <param name="builder">The builder.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        public static IMassTransitRabbitMqHostingBuilder ConsumeByConvention<TConsumer, TMessage>(this IMassTransitRabbitMqHostingBuilder builder,
-                                                                                                  Action<IRetryConfigurator> retry = null)
+        public static IMassTransitRabbitMqHostingBuilder ConsumeByConvention<TConsumer, TMessage>(
+            this IMassTransitRabbitMqHostingBuilder builder,
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class
-            => builder.Consume<TConsumer, TMessage>(builder.GetQueueName<TMessage>(), retry);
+            => builder.Consume<TConsumer, TMessage>(builder.GetQueueName<TMessage>(), retry, receiveEndpointConfigurator);
 
         /// <summary>
         /// Configures a fault consumer of the specified type.
@@ -49,13 +53,16 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
         /// <param name="builder">The builder.</param>
         /// <param name="queueName">Name of the queue.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        public static IMassTransitRabbitMqHostingBuilder ConsumeFault<TConsumer, TMessage>(this IMassTransitRabbitMqHostingBuilder builder,
-                                                                                           string queueName,
-                                                                                           Action<IRetryConfigurator> retry = null)
+        public static IMassTransitRabbitMqHostingBuilder ConsumeFault<TConsumer, TMessage>(
+            this IMassTransitRabbitMqHostingBuilder builder,
+            string queueName,
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<Fault<TMessage>>
             where TMessage : class
-            => builder.Consume<TConsumer, Fault<TMessage>>($"{queueName}_{FaultQueuePostfix}", retry);
+            => builder.Consume<TConsumer, Fault<TMessage>>($"{queueName}_{FaultQueuePostfix}", retry, receiveEndpointConfigurator);
 
         /// <summary>
         /// Configures a fault consumer of the specified type via convention.
@@ -66,12 +73,15 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
         /// <typeparam name="TMessage">The type of the message.</typeparam>
         /// <param name="builder">The builder.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        public static IMassTransitRabbitMqHostingBuilder ConsumeFaultByConvention<TConsumer, TMessage>(this IMassTransitRabbitMqHostingBuilder builder,
-                                                                                                       Action<IRetryConfigurator> retry = null)
+        public static IMassTransitRabbitMqHostingBuilder ConsumeFaultByConvention<TConsumer, TMessage>(
+            this IMassTransitRabbitMqHostingBuilder builder,
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<Fault<TMessage>>
             where TMessage : class
-            => builder.Consume<TConsumer, Fault<TMessage>>($"{builder.GetQueueName<TMessage>()}_{FaultQueuePostfix}", retry);
+            => builder.Consume<TConsumer, Fault<TMessage>>($"{builder.GetQueueName<TMessage>()}_{FaultQueuePostfix}", retry, receiveEndpointConfigurator);
 
         /// <summary>
         /// Configures an error consumer of the specified type.
@@ -83,13 +93,16 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
         /// <param name="builder">The builder.</param>
         /// <param name="queueName">Name of the queue.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        public static IMassTransitRabbitMqHostingBuilder ConsumeError<TConsumer, TMessage>(this IMassTransitRabbitMqHostingBuilder builder,
-                                                                                           string queueName,
-                                                                                           Action<IRetryConfigurator> retry = null)
+        public static IMassTransitRabbitMqHostingBuilder ConsumeError<TConsumer, TMessage>(
+            this IMassTransitRabbitMqHostingBuilder builder,
+            string queueName,
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class
-            => builder.Consume<TConsumer, TMessage>($"{queueName}_{ErrorQueuePostfix}", retry);
+            => builder.Consume<TConsumer, TMessage>($"{queueName}_{ErrorQueuePostfix}", retry, receiveEndpointConfigurator);
 
         /// <summary>
         /// Configures an error consumer of the specified type via convention.
@@ -101,13 +114,16 @@ namespace MassTransit.RabbitMq.Extensions.Hosting.Extensions
         /// <param name="builder">The builder.</param>
         /// <param name="remoteApplicationName">Name of the remote application.</param>
         /// <param name="retry">The optional retry configurator action.</param>
+        /// <param name="receiveEndpointConfigurator">The optional endpoint configurator action.</param>
         /// <returns></returns>
-        public static IMassTransitRabbitMqHostingBuilder ConsumeErrorByConvention<TConsumer, TMessage>(this IMassTransitRabbitMqHostingBuilder builder,
-                                                                                                       string remoteApplicationName,
-                                                                                                       Action<IRetryConfigurator> retry = null)
+        public static IMassTransitRabbitMqHostingBuilder ConsumeErrorByConvention<TConsumer, TMessage>(
+            this IMassTransitRabbitMqHostingBuilder builder,
+            string remoteApplicationName,
+            Action<IRetryConfigurator> retry = null,
+            Action<IRabbitMqReceiveEndpointConfigurator> receiveEndpointConfigurator = null)
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class
-            => builder.Consume<TConsumer, TMessage>($"{GetQueueName<TMessage>(remoteApplicationName)}_{ErrorQueuePostfix}", retry);
+            => builder.Consume<TConsumer, TMessage>($"{GetQueueName<TMessage>(remoteApplicationName)}_{ErrorQueuePostfix}", retry, receiveEndpointConfigurator);
 
         /// <summary>
         /// Configures a send endpoint and a timeout for responses via convention.

--- a/src/MassTransit.RabbitMq.Extensions.Hosting/MassTransit.RabbitMq.Extensions.Hosting.csproj
+++ b/src/MassTransit.RabbitMq.Extensions.Hosting/MassTransit.RabbitMq.Extensions.Hosting.csproj
@@ -21,14 +21,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.2.0" />
-    <PackageReference Include="MassTransit.Extensions.Logging" Version="4.0.1" />
-    <PackageReference Include="MassTransit.RabbitMQ" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
+    <PackageReference Include="Humanizer.Core" Version="2.5.1" />
+    <PackageReference Include="MassTransit.Extensions.Logging" Version="5.1.5" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add access to IRabbitMqReceiveEndpointConfigurator in add consumers extension methods

You may need it for example when you want to configure prefetch count for consumer.